### PR TITLE
DOCS : feature 이미지 안뜨는 오류. 파일 확장자를 대문자로 변경

### DIFF
--- a/workflow.md
+++ b/workflow.md
@@ -24,4 +24,4 @@ ___
 
 이를 feature 브랜치라고 하자.
 
-![feature 브랜치](./img/featureBranch.jpg)
+![feature 브랜치](./img/featureBranch.JPG)


### PR DESCRIPTION
로컬에서는 이미지가 뜨는데 깃헙에서는 안뜨는 이유가 파일 확장자가 JPG인데 .jpg로 불러와서인 것 같습니다!
수정했습니다~